### PR TITLE
Update WorkSpaces download recipe to use region-specific URL

### DIFF
--- a/WorkSpaces/WorkSpaces.download.recipe
+++ b/WorkSpaces/WorkSpaces.download.recipe
@@ -21,7 +21,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>https://d2td7dqidlhjx7.cloudfront.net/prod/global/osx/WorkSpaces.pkg</string>
+                <string>https://d2td7dqidlhjx7.cloudfront.net/prod/pdx/osx/WorkSpaces.pkg</string>
                 <key>filename</key>
                 <string>%NAME%.pkg</string>
             </dict>


### PR DESCRIPTION
This PR will fix Issue #7 by modifying the `url` key for `URLDownloader` to use a region-specific -- specifically, the `pdx` region; i.e. `us-west-2` or "US West (Oregon)" -- CloudFront URL instead of the `global` URL.

My team discovered that the `global` URL (`https://d2td7dqidlhjx7.cloudfront.net/prod/global/osx/WorkSpaces.pkg`), which this recipe uses, is not distributing the latest client package version last week and contact AWS Support to see what was going on. AWS Support recommended a workaround for us which was that we use the `pdx` region URL over the `global` URL as it will pull the latest version is retrieved from CloudFront.

Here is the `Info.plist`'s `CFBundleVersion` of the `.pkg` when the file is pulled from the `global` URL:
![image](https://user-images.githubusercontent.com/24925402/77630724-d0879c00-6f4b-11ea-8854-50e1d361334e.png)

Here is the `Info.plist`'s `CFBundleVersion` of the `.pkg` when the file is pulled from the `pdx` URL:
![image](https://user-images.githubusercontent.com/24925402/77630854-03319480-6f4c-11ea-95cd-9b5633516d58.png)

Therefore, this PR will modify the URL to reflect using `pdx` to ensure that people using this recipe will be getting the latest installer.