### PR TITLE
Update CompanyPortal.munki.recipe

### DIFF
--- a/CompanyPortal/CompanyPortal.munki.recipe
+++ b/CompanyPortal/CompanyPortal.munki.recipe
@@ -3,11 +3,15 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release of Microsoft Company Portal and imports into Munki.</string>
+    <string>Downloads the current release of Microsoft Company Portal and imports into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.jlehikoinen.munki.CompanyPortal</string>
     <key>Input</key>
     <dict>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/Microsoft</string>
         <key>NAME</key>
@@ -33,7 +37,7 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.6.1</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
     <string>com.github.jlehikoinen.download.CompanyPortal</string>
     <key>Process</key>
@@ -81,6 +85,8 @@
                 <array>
                     <string>/Applications/Company Portal.app</string>
                 </array>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Hi, @jlehikoinen 

The CompanyPortal Munki recipe currently doesn't set the `minimum_os_version` from the App's info.plist, and as such a default value of 10.5.0 is being set.

This PR adds in support for the new `derive_minimum_os_version` key in the `MunkiInstallsItemsCreator` processor. With this set the min_os_version becomes 10.15

This change requires AutoPkg version 2.7 or higher, if compatibility with older versions of AutoPkg is needed, the same result could be achieved with something like below.

```
        <dict>
            <key>Arguments</key>
            <dict>
                <key>info_path</key>
                <string>%RECIPE_CACHE_DIR%/Applications/APP_NAME.app</string>
                <key>plist_keys</key>
                <dict>
                    <key>LSMinimumSystemVersion</key>
                    <string>min_os_ver</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>PlistReader</string>
        </dict>
        <dict>
             <key>Arguments</key>
             <dict>
                <key>additional_pkginfo</key>
                <dict>
                    <key>minimum_os_version</key>
                    <string>%min_os_ver%</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>MunkiPkginfoMerger</string>
        </dict>
```

Output from a successful verbose run:

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/jlehikoinen-recipes/CompanyPortal/CompanyPortal.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/jlehikoinen-recipes/CompanyPortal/CompanyPortal.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/jlehikoinen-recipes/CompanyPortal/CompanyPortal.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Fri, 16 Dec 2022 19:42:23 GMT
URLDownloader: Storing new ETag header: "0xF4BBC1BD5C70F0C449426153E2B935E1F12CB3862FE69F2B1C8F87FE2AB3D289"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.jlehikoinen.munki.CompanyPortal/downloads/CompanyPortal.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "CompanyPortal.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2022-12-16 01:52:26 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Microsoft Corporation (UBF8T346G9)
CodeSignatureVerifier:        Expires: 2023-05-16 04:46:41 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            6A 66 CD 33 B5 5B 9C 14 86 02 29 09 DB 7E 00 85 53 11 29 6B CE 11 
CodeSignatureVerifier:            9F 2A 93 5C 69 BF 56 3A 79 82
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.jlehikoinen.munki.CompanyPortal/downloads/CompanyPortal.pkg to /Users/paul/Library/AutoPkg/Cache/com.github.jlehikoinen.munki.CompanyPortal/pkg_unpack
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.jlehikoinen.munki.CompanyPortal/pkg_unpack/CompanyPortal-Component.pkg/Payload to /Users/paul/Library/AutoPkg/Cache/com.github.jlehikoinen.munki.CompanyPortal
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Company Portal.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.15
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.microsoft.CompanyPortalMac', 'CFBundleName': 'Company Portal', 'CFBundleShortVersionString': '5.2212.0', 'CFBundleVersion': '53.2212990.001', 'minosversion': '10.15', 'path': '/Applications/Company Portal.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.15'} into pkginfo
Versioner
Versioner: Found version 5.2212.0 in file /Users/paul/Library/AutoPkg/Cache/com.github.jlehikoinen.munki.CompanyPortal/Applications/Company Portal.app/Contents/Info.plist
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '5.2212.0'} into pkginfo
DmgCreator
DmgCreator: Created dmg from /Users/paul/Library/AutoPkg/Cache/com.github.jlehikoinen.munki.CompanyPortal/downloads/CompanyPortal.pkg at /Users/paul/Library/AutoPkg/Cache/com.github.jlehikoinen.munki.CompanyPortal/CompanyPortal.dmg
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Microsoft/CompanyPortal-5.2212.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Microsoft/CompanyPortal-5.2212.0.dmg
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.jlehikoinen.munki.CompanyPortal/pkg_unpack
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.jlehikoinen.munki.CompanyPortal/Applications/Company Portal.app
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.jlehikoinen.munki.CompanyPortal/receipts/CompanyPortal.munki-receipt-20221221-160609.plist

The following new items were downloaded:
    Download Path                                                                                             
    -------------                                                                                             
    /Users/paul/Library/AutoPkg/Cache/com.github.jlehikoinen.munki.CompanyPortal/downloads/CompanyPortal.pkg  

The following new items were imported into Munki:
    Name           Version   Catalogs  Pkginfo Path                                 Pkg Repo Path                              Icon Repo Path  
    ----           -------   --------  ------------                                 -------------                              --------------  
    CompanyPortal  5.2212.0  testing   apps/Microsoft/CompanyPortal-5.2212.0.plist  apps/Microsoft/CompanyPortal-5.2212.0.dmg
```
