### PR TITLE
Deprecate Skype recipes

### DIFF
--- a/SkypeForBusinessWebApp/SkypeForBusinessWebApp.download.recipe
+++ b/SkypeForBusinessWebApp/SkypeForBusinessWebApp.download.recipe
@@ -17,6 +17,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the MicrosoftSkypeForBusiness365 recipes in the rtrouton-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This PR deprecates the non-working Skype for Business Web App recipes, and points users to working equivalents in the rtrouton-recipes repo.
