### PR TITLE
Deprecate Yammer recipes

### DIFF
--- a/Yammer/Yammer.download.recipe
+++ b/Yammer/Yammer.download.recipe
@@ -12,9 +12,18 @@
         <string>MSYammer</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.6.1</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Microsoft Yammer is no longer downloadable with the transition to the web-based Viva Engage product (details: https://www.microsoft.com/en-us/microsoft-365/blog/2023/02/13/yammer-is-evolving-to-microsoft-viva-engage-with-new-experiences-rolling-out-today/). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
Microsoft Yammer is no longer downloadable with the transition to the web-based Viva Engage product (details: https://www.microsoft.com/en-us/microsoft-365/blog/2023/02/13/yammer-is-evolving-to-microsoft-viva-engage-with-new-experiences-rolling-out-today/).

This PR deprecates the Yammer recipes in this repo.